### PR TITLE
Fix loader persistence on dashboard

### DIFF
--- a/src/components/AnalyticsDashboard.js
+++ b/src/components/AnalyticsDashboard.js
@@ -405,7 +405,11 @@ const AnalyticsDashboard = ({ dateRange, selectedCompany }) => {
   const SalesServiceTab = () => {
     const [domain, setDomain] = useState(null);
 
-    if (!data.salesServiceData) return <Loading />;
+    if (loading) return <Loading />;
+    if (!data.salesServiceData)
+      return (
+        <div className="p-4 text-center">Keine Daten verfügbar</div>
+      );
 
     // List of clients that should only have Sales view (no Service toggle)
     const salesOnlyClients = ["Galeria", "ADAC", "Urlaub"];
@@ -681,7 +685,11 @@ const AnalyticsDashboard = ({ dateRange, selectedCompany }) => {
   };
 
   const BookingTab = () => {
-    if (!data.bookingData || !data.bookingSubKPIs) return <Loading />;
+    if (loading) return <Loading />;
+    if (!data.bookingData || !data.bookingSubKPIs)
+      return (
+        <div className="p-4 text-center">Keine Daten verfügbar</div>
+      );
 
     const bookingData = data.bookingData || {};
     const bookingSubKPIs = data.bookingSubKPIs || {};

--- a/src/components/CallAnalysisDashboard.js
+++ b/src/components/CallAnalysisDashboard.js
@@ -392,7 +392,11 @@ const CallAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   };
 
   const UebersichtTab = () => {
-    if (loading || !overviewData || !subKPIs) return <Loading />;
+    if (loading) return <Loading />;
+    if (!overviewData || !subKPIs)
+      return (
+        <div className="p-4 text-center">Keine Daten verfügbar</div>
+      );
 
     const uebersichtStats = [
       {
@@ -668,7 +672,9 @@ const CallAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   };
 
   const PerformanceTab = () => {
-    if (!performanceData) return <Loading />;
+    if (loading) return <Loading />;
+    if (!performanceData)
+      return <div className="p-4 text-center">Keine Daten verfügbar</div>;
 
     const anrufGruende = performanceData["Call Reasons Breakdown"] || {};
     const warteschlangenDaten = performanceData["Call By queue"] || {};

--- a/src/components/EmailAnalysisDashboard.js
+++ b/src/components/EmailAnalysisDashboard.js
@@ -373,7 +373,11 @@ const EmailAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   ];
 
   const UebersichtTab = () => {
-    if (!overviewData || !subKPIs) return <Loading />;
+    if (loading) return <Loading />;
+    if (!overviewData || !subKPIs)
+      return (
+        <div className="p-4 text-center">Keine Daten verfügbar</div>
+      );
 
     // Get values from both data sources, with fallbacks
     const slGross = emailData?.['SL Gross'] || 0;
@@ -621,7 +625,9 @@ const EmailAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   };
 
   const LeistungTab = () => {
-    if (!performanceData) return <Loading />;
+    if (loading) return <Loading />;
+    if (!performanceData)
+      return <div className="p-4 text-center">Keine Daten verfügbar</div>;
 
     return (
       <div className="space-y-6">

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -49,8 +49,11 @@ const ProtectedRoute = ({ children }) => {
         setIsLoading(false); // Finish loading state
       }
     };
+    const timeoutId = setTimeout(() => setIsLoading(false), 10000); // safety timeout
 
     checkAuth();
+
+    return () => clearTimeout(timeoutId);
   }, [router]);
 
   if (isLoading) {

--- a/src/components/TaskAnalyis.js
+++ b/src/components/TaskAnalyis.js
@@ -331,7 +331,9 @@ const TaskAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   ];
 
   const OverviewTab = () => {
-    if (!data.kpis || !data.overview) return <Loading />;
+    if (loading) return <Loading />;
+    if (!data.kpis || !data.overview)
+      return <div className="p-4 text-center">Keine Daten verfügbar</div>;
 
     const tasksByWeekday = data.overview['Tasks created by weekday'] || [];
     const tasksByMonth = data.overview['Tasks created by date'] || [];
@@ -471,7 +473,9 @@ const TaskAnalysisDashboard = ({ dateRange, selectedCompany }) => {
   };
 
   const PerformanceTab = () => {
-    if (!data.performance) return <Loading />;
+    if (loading) return <Loading />;
+    if (!data.performance)
+      return <div className="p-4 text-center">Keine Daten verfügbar</div>;
 
     // Chart styling configuration
     const chartStyle = {


### PR DESCRIPTION
## Summary
- prevent infinite loader when verifying auth
- avoid loader when data is missing in analysis dashboards

## Testing
- `npm run lint` *(fails: `next` not found)*